### PR TITLE
Fix QHA failed-EOS previews and support four-volume EOS fits

### DIFF
--- a/src/quantas/core/physics/eos/energy.py
+++ b/src/quantas/core/physics/eos/energy.py
@@ -194,6 +194,7 @@ class EnergyEOS:
                         np.clip(np.diag(resolved_covariance), 0.0, None)
                     ).tolist()
                 else:
+                    assert covariance_warning is not None
                     result.covariance = None
                     result.errors = None
                     result.optimizer_covariance = None

--- a/src/quantas/core/physics/eos/energy.py
+++ b/src/quantas/core/physics/eos/energy.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from quantas.core.math.fitting import (
     BaseFitModel,
+    FitQuality,
     FitResult,
     FitStatus,
     LeastSquaresFitter,
@@ -161,15 +162,55 @@ class EnergyEOS:
                 },
             }
             if result.covariance is not None:
-                resolved_covariance = resolved_energy_parameter_covariance(
-                    model_spec,
-                    result.parameters,
-                    result.covariance,
-                )
-                resolved_metadata["resolved_covariance"] = resolved_covariance.tolist()
-                resolved_metadata["resolved_errors"] = np.sqrt(
-                    np.clip(np.diag(resolved_covariance), 0.0, None)
-                ).tolist()
+                covariance = np.asarray(result.covariance, dtype=np.float64)
+                covariance_status: str | None = None
+                covariance_warning: str | None = None
+                if result.dof == 0:
+                    covariance_status = "unavailable_zero_degrees_of_freedom"
+                    covariance_warning = (
+                        f"the {model_spec.tag} fit is exactly determined: "
+                        f"{result.n_points} observations and "
+                        f"{result.n_parameters} free parameters give zero "
+                        "residual degrees of freedom; parameter covariance and "
+                        "statistical uncertainties are unavailable"
+                    )
+                elif not np.all(np.isfinite(covariance)):
+                    covariance_status = "unavailable_non_finite"
+                    covariance_warning = (
+                        "the optimizer returned a non-finite EOS covariance; "
+                        "parameter uncertainties are unavailable"
+                    )
+
+                if covariance_status is None:
+                    resolved_covariance = resolved_energy_parameter_covariance(
+                        model_spec,
+                        result.parameters,
+                        covariance,
+                    )
+                    resolved_metadata["resolved_covariance"] = (
+                        resolved_covariance.tolist()
+                    )
+                    resolved_metadata["resolved_errors"] = np.sqrt(
+                        np.clip(np.diag(resolved_covariance), 0.0, None)
+                    ).tolist()
+                else:
+                    result.covariance = None
+                    result.errors = None
+                    result.optimizer_covariance = None
+                    result.optimizer_errors = None
+                    result.condition_number = None
+                    result.quality = FitQuality.POOR
+                    result.message = "fit converged with diagnostic warnings"
+                    if covariance_warning not in result.warnings:
+                        result.warnings.append(covariance_warning)
+                    if result.diagnostics is not None:
+                        result.diagnostics.correlation = None
+                        if covariance_warning not in result.diagnostics.warnings:
+                            result.diagnostics.warnings.append(covariance_warning)
+                        result.diagnostics.metadata["covariance_status"] = (
+                            covariance_status
+                        )
+                    resolved_metadata["covariance_status"] = covariance_status
             result.metadata.update(resolved_metadata)
         return result
 
@@ -199,11 +240,12 @@ class EnergyEOS:
     ) -> EOSParameters:
         """Estimate a complete physical parameter set from a polynomial fit."""
         volume_array, energy_array = validate_xy(volume, energy)
-        if volume_array.size < 5:
+        if volume_array.size < 4:
             raise ValueError(
-                "at least five points are required for the EOS initial estimate"
+                "at least four points are required for the EOS initial estimate"
             )
-        coefficients = np.polyfit(volume_array, energy_array, 4)
+        degree = 4 if volume_array.size >= 5 else 2
+        coefficients = np.polyfit(volume_array, energy_array, degree)
         first = np.polyder(coefficients, 1)
         second = np.polyder(coefficients, 2)
         roots = np.roots(first)

--- a/src/quantas/modules/qha/inspect.py
+++ b/src/quantas/modules/qha/inspect.py
@@ -164,8 +164,20 @@ class PressureVolumePreview:
             Rows containing volume, energy, polynomial pressure and EOS
             pressure.  Missing estimates are represented by ``None``.
         """
-        poly = None if self.polynomial is None else self.polynomial.pressure
-        eos = None if self.eos is None else self.eos.pressure
+        poly = (
+            None
+            if self.polynomial is None
+            or not self.polynomial.success
+            or self.polynomial.pressure.shape != self.volume.shape
+            else self.polynomial.pressure
+        )
+        eos = (
+            None
+            if self.eos is None
+            or not self.eos.success
+            or self.eos.pressure.shape != self.volume.shape
+            else self.eos.pressure
+        )
         rows: list[dict[str, float | None]] = []
         for index, (volume, energy) in enumerate(
             zip(self.volume, self.energy, strict=True)

--- a/tests/modules/qha/test_eos_integration.py
+++ b/tests/modules/qha/test_eos_integration.py
@@ -264,3 +264,36 @@ def test_bm_alias_is_identical_to_bm3_in_qha() -> None:
     np.testing.assert_array_equal(
         alias.bulk_modulus_derivative, explicit.bulk_modulus_derivative
     )
+
+
+def test_qha_eos_workflow_accepts_four_volume_bm3_without_covariance() -> None:
+    volume = np.array([68.0, 70.5, 73.0, 76.0], dtype=np.float64)
+    k0_gpa = 160.0
+    k0_native = float(pressure_to_energy(k0_gpa, "eV", "A", "GPa"))
+    parameters = np.array([-100.0, k0_native, 4.2, 72.0], dtype=np.float64)
+    energy = EnergyEOS().evaluate("BM3", volume, parameters)
+    input_data = QHAInput(jobname="four-volume-bm3", volume=volume, energy=energy)
+    options = _options(
+        eos="BM3",
+        pressure_max=0.0,
+        estimate_uncertainties=True,
+        uncertainty_method="covariance",
+    )
+
+    result = run_volume_minimization_workflow(
+        input_data,
+        options,
+        free_energy=energy[np.newaxis, :],
+    )
+
+    assert result.completed
+    assert result.valid_mask.all()
+    fit = result.fit_records[0].fit
+    assert fit.success
+    assert fit.dof == 0
+    assert fit.covariance is None
+    assert any("exactly determined" in warning for warning in fit.warnings)
+    np.testing.assert_allclose(result.equilibrium_volume[0, 0], 72.0, atol=1.0e-7)
+    np.testing.assert_allclose(
+        result.isothermal_bulk_modulus[0, 0], k0_gpa, rtol=1.0e-7
+    )

--- a/tests/modules/qha/test_inspect.py
+++ b/tests/modules/qha/test_inspect.py
@@ -93,3 +93,4 @@ def test_pressure_volume_preview_reports_failed_eos_without_failing_polynomial()
     assert preview.eos is not None
     assert not preview.eos.success
     assert preview.warnings
+    assert all(row["pressure_eos"] is None for row in preview.table_rows())

--- a/tests/physics/eos/test_energy_models.py
+++ b/tests/physics/eos/test_energy_models.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from quantas.core.physics.eos import EnergyEOS
-from quantas.core.math.fitting import FitStatus
+from quantas.core.math.fitting import FitQuality, FitStatus
 
 
 def _reference_murnaghan(volume, E0, K0, KP, V0):
@@ -106,13 +106,38 @@ def test_energy_fit_returns_failure_for_invalid_data():
     assert result.status is FitStatus.INVALID_INPUT
 
 
-def test_energy_fit_reports_initial_guess_failure():
+def test_energy_fit_accepts_exactly_determined_four_point_bm3():
     eos = EnergyEOS()
-    result = eos.fit("BM", [1.0, 2.0, 3.0, 4.0], [3.0, 2.0, 2.0, 3.0])
+    volume = np.array([68.0, 70.5, 73.0, 76.0], dtype=np.float64)
+    expected = np.array([-100.0, 0.55, 4.2, 72.0], dtype=np.float64)
+    energy = eos.evaluate("BM3", volume, expected)
+
+    result = eos.fit("BM3", volume, energy)
+
+    assert result.success, result.message
+    assert result.status is FitStatus.SUCCESS
+    assert result.quality is FitQuality.POOR
+    assert result.dof == 0
+    assert result.covariance is None
+    assert result.errors is None
+    assert result.metadata["covariance_status"] == (
+        "unavailable_zero_degrees_of_freedom"
+    )
+    assert any("exactly determined" in warning for warning in result.warnings)
+    np.testing.assert_allclose(result.parameters, expected, rtol=1.0e-7, atol=1.0e-8)
+
+
+def test_energy_fit_rejects_four_points_for_five_parameter_bm4():
+    eos = EnergyEOS()
+    volume = np.array([68.0, 70.5, 73.0, 76.0], dtype=np.float64)
+    parameters = np.array([-100.0, 0.55, 4.2, -0.04, 72.0], dtype=np.float64)
+    energy = eos.evaluate("BM4", volume, parameters)
+
+    result = eos.fit("BM4", volume, energy)
 
     assert not result.success
-    assert result.status is FitStatus.FAILED
-    assert "initial EOS parameters" in result.message
+    assert result.status is FitStatus.INVALID_INPUT
+    assert "smaller than the number of parameters" in result.message
 
 
 def test_energy_eos_pressure_is_zero_at_reference_volume():


### PR DESCRIPTION
# Summary

This pull request fixes two issues discovered while validating the QHA workflow against the official CRYSTAL14 Al2O3 QHA dataset.


# Failed EOS preview rendering

- Treats failed or shape-incompatible pressure estimates as unavailable.
- Preserves the original failed estimate and its diagnostics.
- Prevents ```PressureVolumePreview.table_rows()``` from indexing empty pressure arrays.
- Adds a regression test for failed EOS preview rendering.


# Four-volume EOS fits

- Allows EOS initial estimates from four energy-volume points.
- Uses a quadratic polynomial only for the four-point initial estimate.
- Preserves the existing fourth-degree initialization for datasets with five or more volumes.
- Supports exactly determined four-parameter EOS fits with zero residual degrees of freedom.
- Omits unavailable covariance and parameter uncertainties.
- Emits an explicit diagnostic warning.
- Continues to reject five-parameter EOS models when only four observations are available.
- Adds EOS unit tests and a QHA integration test.


# Validation

Targeted tests:

```35 passed```


# Full validation:

```python tools/run_tests.py all -- -q```


# Real-data reproduction:

```quantas qha run qha_input_file_with_four_volumes.yaml```


# Issues
Closes #2 
Closes #3 