### PR TITLE
Complete the public SEISMIC input-generation API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ public contract; they must still be documented and validated.
 - Added public Elasticity input generation and principal-plane table export,
   public HA/QHA table writers, and a QHA-owned entry point to the shared phonon
   input generator.
+- Added a workflow-owned ``quantas.api.seismic.create_input()`` entry point,
+  a matching ``quantas seismic inpgen`` command, and ``CREATE_INPUT`` registry
+  capability for the shared CRYSTAL/VASP elastic input format.  SEISMIC
+  generation requires finite positive density metadata.
 - Added public rotation, structure, symmetry, seismic selector, thermoelastic
   fitting/coupling, and EOS model types needed to construct annotated public
   inputs, options, and requests without implementation imports.
@@ -57,12 +61,17 @@ public contract; they must still be documented and validated.
 
 ### Changed
 
+- Constrained package metadata to Python 3.10--3.13 until the complete
+  scientific dependency stack and validation suite are certified on Python 3.14.
 - Public workflow facades and the immediately affected CLI plotting adapters now
   reference plot contracts through ``quantas.api.plotting`` instead of relying
   on the implementation namespace.
 - Centralized SEISMIC scalar-property discovery so the public inventory and the
   existing plot builders derive labels and availability from one authoritative
   result-aware catalogue.
+- Extended the VASP elasticity interface to derive cell density from ``POMASS``,
+  ``ions per type``, and the final reported cell volume when those metadata are
+  available.
 - Centralized HA plot keys, names, mathematical symbols, plain symbols, and
   scientific categories so inventory discovery and existing builders use one
   authoritative backend catalogue.
@@ -84,6 +93,9 @@ public contract; they must still be documented and validated.
 
 ### Fixed
 
+- Rejected native SEISMIC HDF5 writes and reads when the stored stiffness
+  matrix is not positive definite or its stability diagnostics are inconsistent,
+  preventing an apparently valid persisted result for a non-propagating medium.
 - Prevented the default Thermoelasticity plot builder from attempting an
   invalid P--T contour for point or one-dimensional analysis archives.  The
   pre-existing priority remains profile, two-dimensional P--T grid, then

--- a/docs/source/api/seismic.rst
+++ b/docs/source/api/seismic.rst
@@ -54,6 +54,8 @@ Passive contracts and selectors
    :members:
    :show-inheritance:
 
+.. autodata:: quantas.api.seismic.InputInterface
+
 The public enums below are the same types used by :class:`Options` and
 :class:`SurfaceOptions`; CLI and GUI clients do not need imports from
 implementation packages.
@@ -89,6 +91,8 @@ implementation packages.
 
 Input and calculation
 ---------------------
+
+.. autofunction:: quantas.api.seismic.create_input
 
 .. autofunction:: quantas.api.seismic.read_input
 

--- a/docs/source/cli/seismic.rst
+++ b/docs/source/cli/seismic.rst
@@ -11,12 +11,18 @@ Recommended sequence
 
 .. code-block:: console
 
+   quantas seismic inpgen OUTCAR --interface vasp --output material.dat
    quantas seismic run material.dat --level phase --ntheta 61 --nphi 121
    quantas seismic run material.dat --level enhancement --output material_final.hdf5
    quantas seismic plot material_final.hdf5 --summary
    quantas seismic plot material_final.hdf5 --2d --property phase_v_s1 \
       --polarizations
    quantas seismic export material_final.hdf5 --output material_fields.csv
+
+``inpgen`` exposes the same CRYSTAL/VASP generator as
+``quantas.api.seismic.create_input``.  Unlike Elasticity generation, SEISMIC
+requires finite positive density metadata and refuses to create a runnable input
+when the external output contains only a stiffness tensor.
 
 A staged resolution study is normally faster than beginning with the densest
 ``enhancement`` calculation.  Converge phase velocities and splitting first,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@ import sys
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "src"))
 
-from quantas import __version__
+from quantas import __version__  # noqa: E402
 
 project = "Quantas"
 author = "Gianfranco Ulian and Giovanni Valdrè"

--- a/docs/source/formats/elasticity_input.rst
+++ b/docs/source/formats/elasticity_input.rst
@@ -129,8 +129,9 @@ SEISMIC requires one additional line after the six matrix rows:
    3174.0
 
 Only the first token is read.  The value must be finite and strictly positive.
-Elasticity ignores no trailing density line by design; use the same shared file
-when possible, but treat the density as part of the SEISMIC contract.
+Elasticity accepts the same trailing density line but does not use it in its
+scientific calculation.  Use the shared file when possible, while treating the
+density as mandatory only for the SEISMIC contract.
 
 Comments and blank lines
 ------------------------
@@ -143,12 +144,31 @@ line.
 Generating inputs from external codes
 --------------------------------------
 
-Supported interfaces can generate the normalized text form:
+Supported interfaces can generate the normalized text form through either
+workflow-owned public API.  The SEISMIC entry point additionally requires the
+source output to provide enough metadata for finite positive density.
 
-.. code-block:: console
+.. code-block:: python
 
-   quantas elasticity inpgen calculation.out --interface crystal
-   quantas elasticity inpgen OUTCAR --interface vasp
+   from quantas.api import elasticity, seismic
+
+   elasticity.create_input(
+       "calculation.out",
+       "elasticity.dat",
+       interface="crystal",
+       jobname="Crystal",
+   )
+   seismic.create_input(
+       "OUTCAR",
+       "seismic.dat",
+       interface="vasp",
+       jobname="Crystal",
+   )
+
+For VASP, density is derived from the species ``POMASS`` values, ``ions per
+type`` populations, and the final reported cell volume.  If these metadata are
+missing or inconsistent, Elasticity can still generate a stiffness-only input,
+whereas SEISMIC input generation fails explicitly.
 
 The parser preserves the Cartesian frame reported by the source code.  User
 rotations belong to the scientific workflow and are recorded in the result;

--- a/docs/source/workflows/seismic.rst
+++ b/docs/source/workflows/seismic.rst
@@ -48,6 +48,15 @@ Phase results are always calculated.  ``group`` includes the phase stage, and
 Input and physical preconditions
 --------------------------------
 
+A shared Quantas elastic input can be generated directly from supported external
+outputs with either the public API or the CLI::
+
+   quantas seismic inpgen OUTPUT --interface crystal --output material.dat
+   quantas seismic inpgen OUTCAR --interface vasp --output material.dat
+
+Both entry points use ``quantas.api.seismic.create_input`` and require density
+metadata in addition to the stiffness tensor.
+
 The stiffness matrix must be finite, symmetric, and expressed in GPa.  SEISMIC
 uses the historical element-wise symmetry criterion
 
@@ -632,6 +641,19 @@ Non-fatal diagnostics are preserved in arrays and metadata:
 A warning count should be interpreted together with its mask and location.  For
 example, unresolved shear polarizations on a symmetry axis are expected and do
 not invalidate the phase speeds there.
+
+During sampling, the calculator emits one operational ``PROGRESS`` event after
+each completed batch.  Its ``current`` and ``total`` fields are monotonic and
+the final progress value is one.  Progress events are transport state for a live
+frontend and are intentionally not duplicated in the persisted event history.
+Settings, input, isotropic references, field completion, warnings, final
+completion, and errors use the same frontend-neutral event model; non-progress
+events are retained in the result envelope and native HDF5 file.
+
+Native HDF5 writing and reopening recheck finite positive density, stiffness
+symmetry, positive definiteness, and consistency of the stored stability
+eigenvalues.  A non-propagating medium therefore cannot be published or reopened
+as an apparently valid native SEISMIC result.
 
 Reports, export, and plots
 --------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "quantas"
 dynamic = ["version"]
 description = "Quantitative analysis of solid-state thermodynamics, elasticity, seismic waves, and equations of state"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 authors = [

--- a/src/quantas/api/registry.py
+++ b/src/quantas/api/registry.py
@@ -369,6 +369,7 @@ _DESCRIPTORS: tuple[ModuleDescriptor, ...] = (
         capabilities=frozenset(
             {
                 *(capability for capability, _ in _STANDARD_RESULT_OPERATIONS),
+                Capability.CREATE_INPUT,
                 Capability.EXPORT,
                 Capability.PLOT_INVENTORY,
             }
@@ -376,9 +377,20 @@ _DESCRIPTORS: tuple[ModuleDescriptor, ...] = (
         operations=(
             *_STANDARD_RESULT_OPERATIONS,
             _PLOT_INVENTORY_OPERATION,
+            (Capability.CREATE_INPUT, "create_input"),
             (Capability.EXPORT, "write_csv"),
         ),
         operation_catalog=(
+            OperationDescriptor(
+                key="create_input",
+                capability=Capability.CREATE_INPUT,
+                function_name="create_input",
+                name="Create SEISMIC input",
+                description=(
+                    "Convert CRYSTAL or VASP elastic output with density to "
+                    "Quantas input."
+                ),
+            ),
             OperationDescriptor(
                 key="export_csv",
                 capability=Capability.EXPORT,

--- a/src/quantas/api/seismic.py
+++ b/src/quantas/api/seismic.py
@@ -4,12 +4,15 @@
 
 from __future__ import annotations
 
+from math import isfinite
 from pathlib import Path
 from typing import Literal
 
 from quantas.core.events import Observer
 from quantas.core.geometry import Hemisphere, TensorRotation, TensorRotationKind
 from quantas.core.physics.seismic import ElasticMedium, SamplingLevel, WaveMode
+from quantas.io.path import ensure_suffix
+from quantas.modules.elasticity.io import ElasticityInputCreator
 from quantas.modules.seismic.api import (
     build_seismic_plots as _build_plots,
     describe_seismic_plot_inventory as _describe_plots,
@@ -39,6 +42,62 @@ from quantas.modules.seismic.plot.spec import (
 
 from .common import ReportTable, ResultData, _public_dir, get_result_payload
 from .plotting import PlotCollection, PlotInventory, SphericalSummarySpec
+
+
+InputInterface = Literal["crystal", "vasp"]
+
+
+def create_input(
+    source: str | Path,
+    destination: str | Path,
+    *,
+    interface: InputInterface = "crystal",
+    jobname: str = "Unknown",
+) -> Path:
+    """Create a Quantas seismic input from an external-code output.
+
+    Parameters
+    ----------
+    source : str or Path
+        CRYSTAL or VASP output containing an elastic stiffness tensor and
+        enough structural metadata to determine a finite positive density.
+    destination : str or Path
+        Destination text path. The ``.dat`` suffix is applied when absent.
+    interface : {"crystal", "vasp"}, optional
+        External-code reader used to interpret ``source``.
+    jobname : str, optional
+        Human-readable title written to the generated input.
+
+    Returns
+    -------
+    Path
+        Written Quantas seismic input path.
+
+    Raises
+    ------
+    ValueError
+        If the interface is unsupported, the source cannot be parsed, or
+        finite positive density metadata are unavailable.
+    OSError
+        If the destination cannot be written.
+    """
+    output = ensure_suffix(destination, ".dat")
+    try:
+        creator = ElasticityInputCreator(interface)
+    except KeyError as exc:
+        raise ValueError(f"Unsupported seismic input interface: {interface}") from exc
+    completed, error = creator.read(source)
+    if not completed:
+        raise ValueError(error or "Unable to create seismic input")
+    if creator.reader is None:
+        raise ValueError("Unable to create seismic input")
+    density = float(creator.reader.density)
+    if not isfinite(density) or density <= 0.0:
+        raise ValueError(
+            "SEISMIC input generation requires finite positive density metadata."
+        )
+    creator.write(output, jobname=jobname)
+    return output
 
 
 def read_input(source: str | Path) -> Input:
@@ -352,6 +411,7 @@ __all__ = [
     "ElasticMedium",
     "Hemisphere",
     "Input",
+    "InputInterface",
     "Options",
     "PlotOptions",
     "Result",
@@ -367,6 +427,7 @@ __all__ = [
     "describe_plots",
     "build_summary",
     "build_surfaces",
+    "create_input",
     "get_result",
     "normalize_input",
     "read_input",

--- a/src/quantas/cli/reference_help.py
+++ b/src/quantas/cli/reference_help.py
@@ -64,6 +64,12 @@ _COMMAND_HELP: Final[Mapping[tuple[str, ...], str]] = {
         "resolution without modifying the archive.  All styling options affect rendering "
         "only."
     ),
+    ("seismic", "inpgen"): (
+        "Generate a Quantas SEISMIC input from an external electronic-structure output.\n\n"
+        "FILENAME is read through the selected CRYSTAL or VASP interface.  Generation "
+        "requires a stiffness tensor and finite positive density metadata; inspect the "
+        "resulting shared elastic input before passing it to 'quantas seismic run'."
+    ),
     ("ha",): (
         "Evaluate harmonic vibrational thermodynamics on one or more fixed volumes.\n\n"
         "The group converts supported phonon outputs to the Quantas YAML contract, runs "

--- a/src/quantas/cli/seismic.py
+++ b/src/quantas/cli/seismic.py
@@ -38,6 +38,7 @@ from quantas.cli.messages import (
     quantas_error,
     quantas_finish,
     quantas_title,
+    prompt,
 )
 from quantas.cli.output import CLIOutput
 from quantas.cli.seismic_observer import SeismicProgressObserver
@@ -54,6 +55,7 @@ from quantas.api.plotting import (
 )
 from quantas.api.seismic import (
     Hemisphere,
+    InputInterface as SeismicInputInterface,
     Options as SeismicOptions,
     PlotOptions as SeismicPlotOptions,
     SurfaceGeometry,
@@ -65,6 +67,7 @@ from quantas.api.seismic import (
     build_report as build_seismic_report,
     build_summary as build_seismic_summary,
     build_surfaces as build_seismic_surfaces,
+    create_input as create_seismic_input,
     read_result as read_seismic_hdf5,
     run as run_seismic,
     write_csv as write_seismic_csv,
@@ -317,6 +320,55 @@ def run(
 
     if not quiet:
         echo_highlight(quantas_finish())
+
+
+@seismic.command(name="inpgen", cls=GroupedCommand)
+@click.argument(
+    "filename", type=click.Path(exists=True, dir_okay=False, path_type=Path)
+)
+@click.option(
+    "-o",
+    "--output",
+    "outfile",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Output input file. Default: input base name + '_seismic_input.dat'.",
+)
+@click.option(
+    "-i",
+    "--interface",
+    type=click.Choice(["crystal", "vasp"], case_sensitive=True),
+    default="crystal",
+    show_default=True,
+    help="Interface used to read the external output file.",
+)
+def inpgen(filename: Path, outfile: Path | None, interface: str) -> None:
+    """Generate a Quantas SEISMIC input from CRYSTAL or VASP output."""
+    if outfile is None:
+        stem = filename.with_suffix("")
+        outfile = stem.with_name(stem.name + "_seismic_input").with_suffix(".dat")
+    else:
+        outfile = outfile.with_suffix(".dat")
+    echo_highlight(quantas_title())
+    try:
+        jobname = prompt(
+            "\nPlease enter a short description for the input file",
+            default="Unknown",
+            show_default=False,
+        )
+        outfile = create_seismic_input(
+            filename,
+            outfile,
+            interface=cast(SeismicInputInterface, interface),
+            jobname=jobname,
+        )
+    except Exception as exc:
+        echo_error(quantas_error(), bold=True)
+        echo_error(str(exc))
+        raise click.Abort() from exc
+    echo(f"SEISMIC input file written to: {outfile}")
+    echo_highlight(render_citation_notice(module_citation_keys("seismic")))
+    echo_highlight(quantas_finish())
 
 
 @seismic.command(name="plot", cls=GroupedCommand)

--- a/src/quantas/interfaces/vasp/elasticity.py
+++ b/src/quantas/interfaces/vasp/elasticity.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import TypedDict
 
@@ -13,6 +14,20 @@ from quantas.models.reader import BasicReader
 
 _CLAMPED_ELASTIC_MODULI = "SYMMETRIZED ELASTIC MODULI (kBar)"
 _RELAXED_ELASTIC_MODULI = "TOTAL ELASTIC MODULI (kBar)"
+_ATOMIC_MASS_UNIT_PER_ANGSTROM_CUBED = 1660.53906660
+
+_POMASS_RE = re.compile(
+    r"POMASS\s*=\s*([-+0-9.EeDd]+)\s*;\s*ZVAL",
+    flags=re.IGNORECASE,
+)
+_IONS_PER_TYPE_RE = re.compile(
+    r"ions\s+per\s+type\s*=\s*([0-9 \t]+)",
+    flags=re.IGNORECASE,
+)
+_VOLUME_RE = re.compile(
+    r"volume\s+of\s+cell\s*:\s*([-+0-9.EeDd]+)",
+    flags=re.IGNORECASE,
+)
 
 
 class _ElasticityData(TypedDict):
@@ -67,7 +82,8 @@ class VASPElasticityReader(BasicReader[None]):
             )
             return
 
-        lines = path.read_text(encoding="utf-8").splitlines()
+        text = path.read_text(encoding="utf-8")
+        lines = text.splitlines()
         start = self.elasticity_start_line(path)
         for row in range(6):
             values = lines[start + row].split()
@@ -86,7 +102,55 @@ class VASPElasticityReader(BasicReader[None]):
         stiffness = self._data["stiffness"]
         stiffness[[3, 5]] = stiffness[[5, 3]]
         stiffness[:, [3, 5]] = stiffness[:, [5, 3]]
+        self._data["density"] = self._read_density(text)
         self.completed = True
+
+    @staticmethod
+    def _read_density(text: str) -> float:
+        """Return the final VASP cell density in kg m^-3 when available.
+
+        VASP reports species masses through ``POMASS``, species populations
+        through ``ions per type``, and one or more cell volumes during a run.
+        The final reported volume is paired with the species-resolved mass.
+        Missing or incomplete metadata leave density unavailable rather than
+        invalidating an otherwise usable Elasticity input.
+        """
+        mass_matches = _POMASS_RE.findall(text)
+        count_matches = _IONS_PER_TYPE_RE.findall(text)
+        volume_matches = _VOLUME_RE.findall(text)
+        if not mass_matches or not count_matches or not volume_matches:
+            return 0.0
+
+        try:
+            masses = np.asarray(
+                [
+                    float(value.replace("D", "E").replace("d", "e"))
+                    for value in mass_matches
+                ],
+                dtype=float,
+            )
+            counts = np.asarray(
+                [int(value) for value in count_matches[0].split()],
+                dtype=int,
+            )
+            volume = float(volume_matches[-1].replace("D", "E").replace("d", "e"))
+        except ValueError:
+            return 0.0
+
+        if (
+            masses.shape != counts.shape
+            or masses.size == 0
+            or np.any(~np.isfinite(masses))
+            or np.any(masses <= 0.0)
+            or np.any(counts <= 0)
+            or not np.isfinite(volume)
+            or volume <= 0.0
+        ):
+            return 0.0
+
+        total_mass = float(np.dot(masses, counts))
+        density = total_mass / volume * _ATOMIC_MASS_UNIT_PER_ANGSTROM_CUBED
+        return float(density) if np.isfinite(density) and density > 0.0 else 0.0
 
     def is_elasticity_output(self, filename: str | Path) -> bool:
         """Return whether a VASP OUTCAR contains an elastic-moduli section."""

--- a/src/quantas/modules/seismic/io/export.py
+++ b/src/quantas/modules/seismic/io/export.py
@@ -11,6 +11,7 @@ from typing import Any
 import h5py
 import numpy as np
 
+from quantas.core.physics.seismic import MODE_INDEX, MODE_ORDER, MODE_SYMBOLS
 from quantas.io.hdf5 import (
     write_diagnostics,
     write_events,
@@ -21,8 +22,8 @@ from quantas.io.hdf5 import (
 )
 from quantas.io.path import ensure_suffix
 from quantas.models import BasicExport, BasicHDF5Export, ResultData
-from quantas.core.physics.seismic import MODE_INDEX, MODE_ORDER, MODE_SYMBOLS
 from quantas.modules.seismic.io.hdf5_payload import (
+    validate_seismic_payload_for_persistence,
     write_seismic_diagnostics,
     write_seismic_payload,
 )
@@ -60,6 +61,7 @@ class SeismicHDF5Export(BasicHDF5Export):
         ):
             raise ValueError("ResultData does not contain a valid seismic result.")
 
+        validate_seismic_payload_for_persistence(payload)
         output = ensure_suffix(filename, ".hdf5")
         with h5py.File(output, "w") as h5:
             write_result_metadata(h5, result)

--- a/src/quantas/modules/seismic/io/hdf5_payload.py
+++ b/src/quantas/modules/seismic/io/hdf5_payload.py
@@ -18,8 +18,12 @@ from numpy.typing import NDArray
 from quantas.core.geometry import Hemisphere, SphericalGrid, spherical_direction
 from quantas.core.physics.elasticity import (
     ElasticAverages,
+    ElasticTensor,
     IsotropicElasticProperties,
     StabilityResult,
+    StiffnessSymmetryCriterion,
+    check_positive_definiteness,
+    validate_stiffness_matrix,
 )
 from quantas.core.physics.seismic import IsotropicSeismicVelocities
 from quantas.core.physics.seismic import (
@@ -48,6 +52,58 @@ from quantas.modules.seismic.models import SeismicResult
 _MODE_ORDER = "v_s2,v_s1,v_p"
 _PAIR_ORDER = "v_s2-v_s1,v_s1-v_p"
 _BRANCH_ORDER = "shear_a,shear_b,p"
+
+
+def validate_seismic_payload_for_persistence(result: SeismicResult) -> None:
+    """Validate invariants required by a native SEISMIC result.
+
+    Native persistence accepts only results with finite positive density and a
+    finite, symmetric, positive-definite stiffness matrix.  Direction-local
+    invalid or degenerate acoustic modes remain representable through their
+    explicit masks and diagnostics.
+
+    Parameters
+    ----------
+    result : SeismicResult
+        Typed SEISMIC payload to validate.
+
+    Raises
+    ------
+    ValueError
+        If the payload cannot represent a physically propagating elastic
+        medium or its stored stability diagnostics are inconsistent.
+    """
+    if not np.isfinite(result.density) or result.density <= 0.0:
+        raise ValueError("Seismic HDF5 density must be finite and positive.")
+
+    matrix = validate_stiffness_matrix(
+        result.stiffness,
+        symmetry_tolerance=1.0e-8,
+        symmetry_criterion=StiffnessSymmetryCriterion.ELEMENTWISE,
+        copy=True,
+    )
+    stability = check_positive_definiteness(
+        ElasticTensor(matrix),
+        tolerance=result.stability.tolerance,
+    )
+    if not stability.is_stable:
+        raise ValueError(
+            "Seismic HDF5 results require a positive-definite stiffness matrix."
+        )
+    if not result.stability.is_stable:
+        raise ValueError(
+            "Stored seismic stability diagnostics are inconsistent with a "
+            "propagating result."
+        )
+    if not np.allclose(
+        result.stability.eigenvalues,
+        stability.eigenvalues,
+        rtol=1.0e-12,
+        atol=1.0e-12,
+    ):
+        raise ValueError(
+            "Stored seismic stability eigenvalues do not match the stiffness matrix."
+        )
 
 
 def write_seismic_payload(h5: h5py.File, result: SeismicResult) -> h5py.Group:
@@ -374,7 +430,7 @@ def read_seismic_payload(h5: h5py.File) -> SeismicResult:
     if diagnostics is not None and "seismic" in diagnostics:
         metadata = read_mapping(diagnostics["seismic"])
 
-    return SeismicResult(
+    result = SeismicResult(
         jobname=decode_text(group.attrs["jobname"]),
         density=density,
         stiffness=stiffness,
@@ -385,6 +441,8 @@ def read_seismic_payload(h5: h5py.File) -> SeismicResult:
         field=field,
         metadata=metadata,
     )
+    validate_seismic_payload_for_persistence(result)
+    return result
 
 
 def _read_stability(group: h5py.Group) -> StabilityResult:

--- a/tests/infrastructure/test_api_surface.py
+++ b/tests/infrastructure/test_api_surface.py
@@ -281,6 +281,7 @@ EXPECTED_PUBLIC_SYMBOLS = {
         "ElasticMedium",
         "Hemisphere",
         "Input",
+        "InputInterface",
         "Options",
         "PlotOptions",
         "Result",
@@ -296,6 +297,7 @@ EXPECTED_PUBLIC_SYMBOLS = {
         "describe_plots",
         "build_summary",
         "build_surfaces",
+        "create_input",
         "get_result",
         "normalize_input",
         "read_input",
@@ -468,6 +470,7 @@ def test_cli_input_and_export_commands_use_public_facades() -> None:
         "elasticity.py",
         "ha.py",
         "qha.py",
+        "seismic.py",
         "phonon_input.py",
     )
     forbidden_fragments = (

--- a/tests/infrastructure/test_public_api.py
+++ b/tests/infrastructure/test_public_api.py
@@ -93,6 +93,7 @@ def test_registry_declares_all_scientific_modules_and_types() -> None:
     assert registry.get("qha").has(Capability.INSPECT)
     assert registry.get("qha").has(Capability.CREATE_INPUT)
     assert registry.get("qha").has(Capability.EXPORT)
+    assert registry.get("seismic").has(Capability.CREATE_INPUT)
     assert registry.get("eos").has(Capability.FIT)
     assert registry.get("eos").has(Capability.PLOT_INVENTORY)
     assert registry.get("eos").operation(Capability.PLOT_INVENTORY) is eos.describe_plots
@@ -111,6 +112,7 @@ def test_registry_describes_multiple_named_operations() -> None:
         elasticity_descriptor.named_operation("export_2d_table")
         is elasticity.write_table
     )
+    assert registry.get("seismic").named_operation("create_input") is seismic.create_input
 
     eos_exports = registry.get("eos").operations_for(Capability.EXPORT)
     assert eos_exports == (eos.write_diagnostic_csv, eos.write_calculation_csv)

--- a/tests/infrastructure/test_public_lifecycle.py
+++ b/tests/infrastructure/test_public_lifecycle.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import pytest
 from click.testing import CliRunner
 
-from quantas.api import elasticity, ha, qha
+from quantas.api import elasticity, ha, qha, seismic
+from quantas.api.common import ResultData, ResultMetadata
 from quantas.cli.elasticity import elasticity as elasticity_cli
 from quantas.cli.ha import ha as ha_cli
 from quantas.cli.qha import qha as qha_cli
-from quantas.api.common import ResultData, ResultMetadata
+from quantas.cli.seismic import seismic as seismic_cli
 
 
 CRYSTAL_ELASTICITY_OUTPUT = (
@@ -20,6 +22,37 @@ CRYSTAL_ELASTICITY_OUTPUT = (
     / "data"
     / "calcite_crystal_elastcon_excerpt.out"
 )
+
+
+def _write_vasp_elasticity_output(
+    path: Path,
+    *,
+    include_density: bool = True,
+) -> Path:
+    """Write a compact VASP elasticity output accepted by the public reader."""
+    matrix = np.diag([2000.0, 2100.0, 2200.0, 700.0, 800.0, 900.0])
+    lines: list[str] = []
+    if include_density:
+        lines.extend(
+            [
+                "POMASS = 24.305; ZVAL = 2.000",
+                "ions per type = 2",
+                "volume of cell : 80.000000",
+            ]
+        )
+    lines.extend(
+        [
+            "SYMMETRIZED ELASTIC MODULI (kBar)",
+            "separator",
+            "separator",
+        ]
+    )
+    lines.extend(
+        f"{row + 1} " + " ".join(str(value) for value in matrix[row])
+        for row in range(6)
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
 
 
 def test_elasticity_public_input_generator_is_runnable(tmp_path: Path) -> None:
@@ -61,6 +94,123 @@ def test_elasticity_cli_input_matches_public_api(tmp_path: Path) -> None:
     )
     assert response.exit_code == 0, response.output
     assert cli_path.read_bytes() == api_path.read_bytes()
+
+
+def test_seismic_cli_input_matches_public_api(tmp_path: Path) -> None:
+    """SEISMIC CLI and API generate identical normalized input text."""
+    api_path = seismic.create_input(
+        CRYSTAL_ELASTICITY_OUTPUT,
+        tmp_path / "api-seismic",
+        interface="crystal",
+        jobname="SEISMIC lifecycle",
+    )
+    cli_path = tmp_path / "cli-seismic.dat"
+    response = CliRunner().invoke(
+        seismic_cli,
+        [
+            "inpgen",
+            str(CRYSTAL_ELASTICITY_OUTPUT),
+            "--output",
+            str(cli_path),
+            "--interface",
+            "crystal",
+        ],
+        input="SEISMIC lifecycle\n",
+    )
+
+    assert response.exit_code == 0, response.output
+    assert cli_path.read_bytes() == api_path.read_bytes()
+
+
+def test_seismic_crystal_input_generator_preserves_density(tmp_path: Path) -> None:
+    """SEISMIC owns a public generator for the shared elastic input format."""
+    output = seismic.create_input(
+        CRYSTAL_ELASTICITY_OUTPUT,
+        tmp_path / "calcite-seismic",
+        interface="crystal",
+        jobname="Calcite seismic API",
+    )
+
+    parsed = seismic.read_input(output)
+    assert parsed.jobname == "Calcite seismic API"
+    assert parsed.stiffness is not None
+    assert parsed.stiffness[0, 4] == 20.67
+    assert parsed.density == 2680.0
+
+
+def test_seismic_and_elasticity_generators_share_input_text(tmp_path: Path) -> None:
+    """Both public namespaces expose byte-identical shared input generation."""
+    elastic_path = elasticity.create_input(
+        CRYSTAL_ELASTICITY_OUTPUT,
+        tmp_path / "elasticity-input",
+        interface="crystal",
+        jobname="Shared input",
+    )
+    seismic_path = seismic.create_input(
+        CRYSTAL_ELASTICITY_OUTPUT,
+        tmp_path / "seismic-input",
+        interface="crystal",
+        jobname="Shared input",
+    )
+
+    assert seismic_path.read_bytes() == elastic_path.read_bytes()
+
+
+def test_seismic_vasp_generator_preserves_density(
+    tmp_path: Path,
+) -> None:
+    """VASP mass, population, and final volume metadata produce kg m^-3."""
+    source = _write_vasp_elasticity_output(tmp_path / "OUTCAR")
+
+    output = seismic.create_input(
+        source,
+        tmp_path / "vasp-seismic",
+        interface="vasp",
+        jobname="VASP seismic API",
+    )
+    parsed = seismic.read_input(output)
+
+    expected_density = 2.0 * 24.305 / 80.0 * 1660.53906660
+    assert parsed.density == pytest.approx(expected_density, rel=5.0e-7)
+    assert parsed.stiffness is not None
+    assert parsed.stiffness[0, 0] == 200.0
+
+
+def test_seismic_cli_vasp_input(tmp_path: Path) -> None:
+    """The CLI exposes the public VASP generator with density preservation."""
+    source = _write_vasp_elasticity_output(tmp_path / "OUTCAR")
+    output = tmp_path / "cli-vasp.dat"
+    response = CliRunner().invoke(
+        seismic_cli,
+        [
+            "inpgen",
+            str(source),
+            "--output",
+            str(output),
+            "--interface",
+            "vasp",
+        ],
+        input="VASP SEISMIC CLI\n",
+    )
+
+    assert response.exit_code == 0, response.output
+    parsed = seismic.read_input(output)
+    expected_density = 2.0 * 24.305 / 80.0 * 1660.53906660
+    assert parsed.jobname == "VASP SEISMIC CLI"
+    assert parsed.density == pytest.approx(expected_density, rel=5.0e-7)
+
+
+def test_seismic_vasp_input_generator_rejects_missing_density(
+    tmp_path: Path,
+) -> None:
+    """A stiffness-only VASP OUTCAR cannot become a runnable SEISMIC input."""
+    source = _write_vasp_elasticity_output(
+        tmp_path / "OUTCAR-no-density",
+        include_density=False,
+    )
+
+    with pytest.raises(ValueError, match="finite positive density"):
+        seismic.create_input(source, tmp_path / "invalid", interface="vasp")
 
 
 def test_qha_input_generator_uses_shared_phonon_contract(

--- a/tests/interfaces/test_elasticity_readers.py
+++ b/tests/interfaces/test_elasticity_readers.py
@@ -69,6 +69,9 @@ def test_vasp_reader_prefers_relaxed_moduli(
     filename.write_text(
         "\n".join(
             [
+                "POMASS = 24.305; ZVAL = 2.000",
+                "ions per type = 2",
+                "volume of cell : 80.000000",
                 *block("SYMMETRIZED ELASTIC MODULI (kBar)", clamped),
                 *block("TOTAL ELASTIC MODULI (kBar)", relaxed),
             ]
@@ -85,6 +88,8 @@ def test_vasp_reader_prefers_relaxed_moduli(
     expected[[3, 5]] = expected[[5, 3]]
     expected[:, [3, 5]] = expected[:, [5, 3]]
     np.testing.assert_allclose(reader.stiffness, expected)
+    expected_density = 2.0 * 24.305 / 80.0 * 1660.53906660
+    assert reader.density == pytest.approx(expected_density)
 
 
 @pytest.mark.interfaces

--- a/tests/modules/seismic/test_io.py
+++ b/tests/modules/seismic/test_io.py
@@ -265,6 +265,31 @@ def test_hdf5_reader_rejects_another_module(tmp_path: Path) -> None:
 
 @pytest.mark.module
 @pytest.mark.seismic
+def test_hdf5_writer_rejects_unstable_stiffness(tmp_path: Path) -> None:
+    result = run_seismic(DATA, options=_options(SamplingLevel.PHASE, tracking=False))
+    payload = result.results["seismic"]
+    assert isinstance(payload, SeismicResult)
+    payload.stiffness[3, 3] = -1.0
+
+    with pytest.raises(ValueError, match="positive-definite"):
+        write_seismic_hdf5(result, tmp_path / "unstable")
+    assert not (tmp_path / "unstable.hdf5").exists()
+
+
+@pytest.mark.module
+@pytest.mark.seismic
+def test_hdf5_reader_rejects_unstable_stiffness(tmp_path: Path) -> None:
+    result = run_seismic(DATA, options=_options(SamplingLevel.PHASE, tracking=False))
+    output = write_seismic_hdf5(result, tmp_path / "tampered")
+    with h5py.File(output, "r+") as h5:
+        h5["results/stiffness"][3, 3] = -1.0
+
+    with pytest.raises(ValueError, match="positive-definite"):
+        read_seismic_hdf5(output)
+
+
+@pytest.mark.module
+@pytest.mark.seismic
 def test_hdf5_writer_rejects_a_non_seismic_result(tmp_path: Path) -> None:
     result = ResultData(metadata=ResultMetadata(module="elasticity"))
     with pytest.raises(ValueError, match="valid seismic result"):

--- a/tests/modules/seismic/test_renderer_cli.py
+++ b/tests/modules/seismic/test_renderer_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import gc
 
+import h5py
 import matplotlib
 import numpy as np
 import pytest
@@ -259,6 +260,65 @@ def test_seismic_run_command_writes_report_and_hdf5_without_figures(
     assert "Sampled phase-velocity extrema" in report
 
 
+def test_cli_and_api_run_match_with_declared_units(tmp_path: Path) -> None:
+    options = SeismicOptions(
+        ntheta=4,
+        nphi=7,
+        hemisphere=Hemisphere.UPPER,
+        level=SamplingLevel.PHASE,
+        batch_size=5,
+        track_polarization_axes=False,
+    )
+    api_result = run_seismic(DATA, options=options)
+    output = tmp_path / "cli_result.hdf5"
+    response = CliRunner().invoke(
+        main,
+        [
+            "seismic",
+            "run",
+            str(DATA),
+            "--ntheta",
+            "4",
+            "--nphi",
+            "7",
+            "--hemisphere",
+            "upper",
+            "--level",
+            "phase",
+            "--batch-size",
+            "5",
+            "--no-track-polarizations",
+            "--quiet",
+            "--output",
+            str(output),
+            "--report",
+            str(tmp_path / "cli_result.log"),
+        ],
+    )
+
+    assert response.exit_code == 0, response.output
+    cli_result = read_seismic_hdf5(output)
+    api_payload = api_result.results["seismic"]
+    cli_payload = cli_result.results["seismic"]
+    np.testing.assert_allclose(
+        cli_payload.field.phase.phase_speeds,
+        api_payload.field.phase.phase_speeds,
+        rtol=0.0,
+        atol=0.0,
+    )
+    np.testing.assert_allclose(
+        cli_payload.grid.directions,
+        api_payload.grid.directions,
+        rtol=0.0,
+        atol=0.0,
+    )
+    assert cli_payload.density == pytest.approx(api_payload.density, rel=0.0, abs=0.0)
+    with h5py.File(output, "r") as h5:
+        assert h5["results"].attrs["density_unit"] == "kg m^-3"
+        assert h5["results/stiffness"].attrs["unit"] == "GPa"
+        assert h5["results/fields/phase/phase_speeds"].attrs["unit"] == "km s^-1"
+
+
 def test_plot_command_writes_requested_outputs(
     tmp_path: Path,
 ) -> None:
@@ -327,7 +387,7 @@ def test_seismic_plot_defaults_to_summary_and_export_writes_csv(tmp_path: Path) 
     assert "phase_speed_km_s" in csv_file.read_text(encoding="utf-8")
 
 
-def test_root_help_exposes_seismic_run_plot_and_export() -> None:
+def test_root_help_exposes_seismic_commands() -> None:
     root = CliRunner().invoke(main, ["--help"])
     assert root.exit_code == 0
     assert "seismic" in root.output
@@ -335,8 +395,14 @@ def test_root_help_exposes_seismic_run_plot_and_export() -> None:
     group = CliRunner().invoke(main, ["seismic", "--help"])
     assert group.exit_code == 0
     assert "run" in group.output
+    assert "inpgen" in group.output
     assert "plot" in group.output
     assert "export" in group.output
+
+    inpgen_help = CliRunner().invoke(main, ["seismic", "inpgen", "--help"])
+    assert inpgen_help.exit_code == 0
+    assert "--interface" in inpgen_help.output
+    assert "--output" in inpgen_help.output
 
     plot_help = CliRunner().invoke(main, ["seismic", "plot", "--help"])
     assert plot_help.exit_code == 0

--- a/tests/modules/seismic/test_workflow.py
+++ b/tests/modules/seismic/test_workflow.py
@@ -109,6 +109,67 @@ def test_public_api_accepts_an_elastic_medium() -> None:
 
 @pytest.mark.module
 @pytest.mark.seismic
+@pytest.mark.parametrize("density", [0.0, -1.0, np.nan, np.inf])
+def test_workflow_rejects_invalid_density(density: float) -> None:
+    invalid = _input()
+    invalid.density = density
+
+    with pytest.raises(ValueError, match="finite and positive"):
+        run_seismic(invalid, options=_options())
+
+
+@pytest.mark.module
+@pytest.mark.seismic
+@pytest.mark.parametrize("hemisphere", list(Hemisphere))
+def test_workflow_supports_each_hemisphere(hemisphere: Hemisphere) -> None:
+    options = SeismicOptions(
+        ntheta=4,
+        nphi=7,
+        hemisphere=hemisphere,
+        level=SamplingLevel.PHASE,
+        batch_size=8,
+        track_polarization_axes=False,
+    )
+
+    result = run_seismic(_input(), options=options)
+    payload = result.results["seismic"]
+
+    assert isinstance(payload, SeismicResult)
+    assert payload.grid.hemisphere is hemisphere
+    assert payload.field.n_points == 28
+
+
+@pytest.mark.module
+@pytest.mark.seismic
+def test_large_grid_progress_is_monotonic_and_not_persisted() -> None:
+    observer = ListObserver()
+    options = SeismicOptions(
+        ntheta=20,
+        nphi=30,
+        hemisphere=Hemisphere.FULL,
+        level=SamplingLevel.PHASE,
+        batch_size=64,
+        track_polarization_axes=False,
+    )
+
+    result = run_seismic(_input(), options=options, observer=observer)
+    progress = [
+        event for event in observer.events if event.level is EventLevel.PROGRESS
+    ]
+
+    values = [event.progress for event in progress]
+    assert values == sorted(values)
+    assert values[-1] == pytest.approx(1.0)
+    assert progress[-1].data == {
+        "kind": "sampling_progress",
+        "current": 600,
+        "total": 600,
+    }
+    assert all(event.level != EventLevel.PROGRESS.value for event in result.events)
+
+
+@pytest.mark.module
+@pytest.mark.seismic
 def test_workflow_rejects_non_positive_definite_stiffness() -> None:
     unstable = SeismicInput(
         jobname="Unstable",


### PR DESCRIPTION
## Summary

Complete the public input-generation lifecycle for the SEISMIC workflow.

This change gives SEISMIC its own semantically appropriate public entry point while retaining the shared Elasticity/SEISMIC input implementation.


## Changes

- add quantas.api.seismic.create_input();
- expose Capability.CREATE_INPUT for SEISMIC through the public registry;
- add quantas seismic inpgen as a thin CLI adapter over the public API;
- support CRYSTAL and VASP elasticity outputs;
- extract and preserve density from VASP OUTCAR files;
- require a finite positive density for SEISMIC input generation;
- retain stiffness-only input generation for Elasticity when density is unavailable;
- strengthen SEISMIC HDF5 validation for density, stiffness symmetry and positive definiteness;
- reject inconsistent or unstable persisted SEISMIC results;
- document the shared Elasticity/SEISMIC input format and public lifecycle;
- restrict the currently supported Python range to <3.14;
- add API, registry, CLI, reader, persistence and lifecycle tests.


## Compatibility
- existing Elasticity input generation remains available;
- the shared input text format remains compatible;
- existing native SEISMIC HDF5 results remain readable when scientifically valid;


## Validation

The focused backend validation passed for:

[X] Ruff lint;
[X] mypy;
[X] source compilation;
[X] public API and registry contracts;
[X] CRYSTAL and VASP readers;
[X] SEISMIC CLI;
[X] SEISMIC workflow and persistence;
[X] scientific SEISMIC kernel;
[X] source and documentation hygiene.

The VASP workflow was also checked manually with a real OUTCAR, producing the expected stiffness tensor and density in the generated input.