### PR TITLE
Expose QHA inspection reports and plots for Quantas 2.0.0b9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,26 @@ Semantic Versioning after the first stable Quantas 2 release.  During the curren
 beta, breaking changes are permitted when they simplify and stabilize the final
 public contract; they must still be documented and validated.
 
-## [2.0.0b8] - Unreleased
+## [2.0.0b9] - Unreleased
+
+### Added
+
+- Added public QHA input-inspection report and energy-volume plot builders.
+  They expose observed points, the selected polynomial and EOS fits, fitted
+  parameters, residual diagnostics, and warnings without requiring frontends
+  to reproduce equation-of-state formulas.
+
+### Changed
+
+- Routed ``quantas qha inspect`` report construction through the same public
+  inspection-report builder available to GUI and library clients.
+
+### Scientific compatibility
+
+No scientific formula, physical convention, HDF5 payload, or stored numerical
+result was changed.
+
+## [2.0.0b8] - 2026-07-31
 
 ### Added
 
@@ -336,6 +355,7 @@ precision, tensor conventions, HDF5 numerical payloads, or validated tolerances 
 the Quantas 2 beta cleanup.  One EOS input enhancement recognizes absolute molar-volume
 units declared through the historical `VSCALE` keyword.
 
+[2.0.0b9]: https://github.com/gfulian/quantas/releases/tag/v2.0.0b9
 [2.0.0b8]: https://github.com/gfulian/quantas/releases/tag/v2.0.0b8
 [2.0.0b6]: https://github.com/gfulian/quantas/releases/tag/v2.0.0b6
 [2.0.0b5]: https://github.com/gfulian/quantas/releases/tag/v2.0.0b5

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ message: >-
   the scientific references reported by the calculation.
 title: Quantas
 type: software
-version: 2.0.0b8
+version: 2.0.0b9
 repository-code: https://github.com/gfulian/quantas
 url: https://quantas.readthedocs.io/
 authors:

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -9,9 +9,9 @@ recorded separately in the Quantas/Quantas GUI architectural decisions.
 
 | Item | Current value |
 |---|---|
-| Last updated | 2026-07-31 |
-| Current development version | `2.0.0b8` |
-| Baseline | `2.0.0b8`, `dev/refactor` |
+| Last updated | 2026-08-02 |
+| Current development version | `2.0.0b9` |
+| Baseline | `2.0.0b9`, `dev/refactor` |
 | Working branch target | `dev/refactor` release-candidate freeze |
 | Development status | Pre-RC scientific validation and release preparation |
 | Numerical baseline | Unchanged from `2.0.0b6` |
@@ -45,7 +45,7 @@ milestones are independent and are not backend RC blockers.
 
 ## Completed backend baseline
 
-The merged `2.0.0b8` baseline provides:
+The `2.0.0b9` baseline provides:
 
 - one supported public Python surface under `quantas.api`;
 - frontend-neutral typed inputs, options, results, reports, plot
@@ -54,6 +54,8 @@ The merged `2.0.0b8` baseline provides:
   plots, and derived exports for supported workflows;
 - result-aware plot inventories for Elasticity, SEISMIC, HA, QHA,
   Thermoelasticity, and the separate EOS archive lifecycle;
+- frontend-neutral QHA input-inspection reports and sampled energy-volume plot
+  specifications built from the same fit preview used by the CLI;
 - public CRYSTAL/VASP Elasticity and SEISMIC input generation, including VASP
   density extraction and finite-positive-density validation for SEISMIC;
 - native SEISMIC HDF5 rejection of unstable or inconsistent elastic media;
@@ -67,7 +69,7 @@ used by the other scientific modules.
 
 No approved numerical algorithm, thermodynamic formulation, unit convention,
 stored scientific array, or HDF5 schema was intentionally changed by the public
-lifecycle and SEISMIC API stabilization work.
+lifecycle, SEISMIC API stabilization, and QHA inspection-presentation work.
 
 ## Verified evidence
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,8 +2,9 @@
 
 ## Source-freeze status
 
-The `2.0.0b8` public lifecycle and SEISMIC input-generation work is merged into
-`dev/refactor`. The backend has returned to release-candidate freeze.
+The `2.0.0b9` public lifecycle baseline, SEISMIC input-generation work, and
+frontend-neutral QHA inspection presentation are merged into `dev/refactor`.
+The backend has returned to release-candidate freeze.
 
 The completed stabilization covers:
 
@@ -14,6 +15,8 @@ The completed stabilization covers:
 - CLI/API equivalence;
 - VASP density extraction for SEISMIC;
 - rejection of unstable native SEISMIC results.
+- public QHA inspection tables and sampled energy-volume plot specifications
+  derived from the existing inspection result without repeating the fit.
 
 It did not intentionally change approved numerical baselines, physical
 conventions, scientific array layouts, or HDF5 schemas.

--- a/docs/source/api/qha.rst
+++ b/docs/source/api/qha.rst
@@ -25,6 +25,8 @@ Recommended lifecycle
        polynomial_degree=3,
        eos="BM3",
    )
+   inspection_tables = qha.build_inspection_report(preview)
+   inspection_plots = qha.build_inspection_plots(preview)
    result_data = qha.run("mgo_b3lyp.yaml", options=options)
    summary = qha.validate_result(result_data)
    result = qha.get_result(result_data)
@@ -107,6 +109,10 @@ Input, inspection, and calculation
 .. autofunction:: quantas.api.qha.normalize_input
 
 .. autofunction:: quantas.api.qha.inspect
+
+.. autofunction:: quantas.api.qha.build_inspection_report
+
+.. autofunction:: quantas.api.qha.build_inspection_plots
 
 .. autofunction:: quantas.api.qha.run
 

--- a/requirements/minimum.txt
+++ b/requirements/minimum.txt
@@ -1,4 +1,4 @@
-# Minimum dependency set declared by Quantas 2.0.0b8.
+# Minimum dependency set declared by Quantas 2.0.0b9.
 numpy==1.24
 scipy==1.10.0
 h5py==3.8.0

--- a/src/quantas/_version.py
+++ b/src/quantas/_version.py
@@ -4,4 +4,4 @@
 
 from __future__ import annotations
 
-__version__ = "2.0.0b8"
+__version__ = "2.0.0b9"

--- a/src/quantas/api/qha.py
+++ b/src/quantas/api/qha.py
@@ -12,6 +12,8 @@ from quantas.core.physics.eos import available_eos_tags
 from quantas.modules.qha.formatting import QHATableFormat as TableFormat
 from quantas.modules.qha.io.export import QHATableExport
 from quantas.modules.qha.api import (
+    build_qha_inspection_plots as _build_inspection_plots,
+    build_qha_inspection_report as _build_inspection_report,
     build_qha_plots as _build_plots,
     build_qha_report as _build_report,
     describe_qha_plot_inventory as _describe_plots,
@@ -198,6 +200,49 @@ def inspect(
         eos=eos,
         maxfev=maxfev,
     )
+
+
+def build_inspection_report(preview: Preview) -> list[ReportTable]:
+    """Build frontend-neutral tables for a QHA input inspection.
+
+    Parameters
+    ----------
+    preview : Preview
+        Structured preview returned by :func:`inspect`.
+
+    Returns
+    -------
+    list of ReportTable
+        Input values, fit diagnostics, and fitted parameter tables.
+    """
+    return _build_inspection_report(preview)
+
+
+def build_inspection_plots(
+    preview: Preview,
+    *,
+    sample_points: int = 201,
+) -> PlotCollection:
+    """Build the frontend-neutral energy-volume inspection plot.
+
+    Successful polynomial and EOS fits are sampled only inside the observed
+    volume interval. The selected EOS and all fit diagnostics come from the
+    supplied :class:`Preview`; no fit is repeated by the frontend.
+
+    Parameters
+    ----------
+    preview : Preview
+        Structured preview returned by :func:`inspect`.
+    sample_points : int, optional
+        Number of points used to sample each successful fitted curve.
+
+    Returns
+    -------
+    PlotCollection
+        Collection containing the observed energy-volume data and every
+        successful fitted curve.
+    """
+    return _build_inspection_plots(preview, sample_points=sample_points)
 
 
 def run(
@@ -467,6 +512,8 @@ __all__ = [
     "ThermalExpansionMethod",
     "ValidationSummary",
     "available_energy_eos",
+    "build_inspection_plots",
+    "build_inspection_report",
     "list_plot_properties",
     "build_plots",
     "build_report",

--- a/src/quantas/api/registry.py
+++ b/src/quantas/api/registry.py
@@ -190,9 +190,7 @@ class ModuleDescriptor:
             )
         operation = getattr(self.load(), operation_name)
         if not callable(operation):
-            raise AttributeError(
-                f"{self.api_module}.{operation_name} is not callable"
-            )
+            raise AttributeError(f"{self.api_module}.{operation_name} is not callable")
         return operation
 
     def list_operations(
@@ -465,6 +463,20 @@ _DESCRIPTORS: tuple[ModuleDescriptor, ...] = (
         ),
         operation_catalog=(
             OperationDescriptor(
+                key="build_inspection_report",
+                capability=Capability.INSPECT,
+                function_name="build_inspection_report",
+                name="Build QHA inspection report",
+                description="Build neutral tables from a QHA input inspection.",
+            ),
+            OperationDescriptor(
+                key="build_inspection_plots",
+                capability=Capability.INSPECT,
+                function_name="build_inspection_plots",
+                name="Build QHA inspection plots",
+                description="Build the sampled static energy-volume fit preview.",
+            ),
+            OperationDescriptor(
                 key="create_input",
                 capability=Capability.CREATE_INPUT,
                 function_name="create_input",
@@ -666,7 +678,9 @@ def get(name: str) -> ModuleDescriptor:
         return _BY_NAME[name]
     except KeyError as exc:
         available = ", ".join(sorted(_BY_NAME))
-        raise KeyError(f"unknown Quantas module {name!r}; available: {available}") from exc
+        raise KeyError(
+            f"unknown Quantas module {name!r}; available: {available}"
+        ) from exc
 
 
 def module_from_result(path: str | Path) -> ModuleDescriptor:

--- a/src/quantas/cli/qha.py
+++ b/src/quantas/cli/qha.py
@@ -57,6 +57,7 @@ from quantas.api.qha import (
     Scheme as QHAScheme,
     ThermalExpansionMethod as QHAThermalExpansionMethod,
     available_energy_eos,
+    build_inspection_report,
     build_plots as build_qha_plots,
     inspect as inspect_qha_input,
     list_plot_properties as list_available_plot_properties,
@@ -69,7 +70,6 @@ from quantas.api.qha import (
 from quantas.cli.output import CLIOutput
 from quantas.cli.qha_observer import QHATextObserver
 from quantas.cli.phonon_input import phonon_inpgen
-from quantas.cli.qha_render import preview_report_tables
 from quantas.renderers.plots import MatplotlibOptions, render_plot_collection
 from quantas.references import module_citation_keys, render_citation_notice
 
@@ -196,7 +196,7 @@ def inspect(
         raise click.Abort() from exc
 
     output = CLIOutput(report_file=report, silent=silent)
-    output.tables(preview_report_tables(preview, include_diagnostics=True))
+    output.tables(build_inspection_report(preview))
     for warning in preview.warnings:
         output.message(warning, level=EventLevel.WARNING)
     output.save()
@@ -815,5 +815,6 @@ def export(
         raise click.ClickException(str(exc)) from exc
 
     echo(f"Written {outfile}")
+
 
 apply_reference_help(qha, ("qha",))

--- a/src/quantas/modules/qha/__init__.py
+++ b/src/quantas/modules/qha/__init__.py
@@ -4,6 +4,8 @@
 
 from .api import (
     MODULE_CONTRACT,
+    build_qha_inspection_plots,
+    build_qha_inspection_report,
     build_qha_plots,
     build_qha_report,
     inspect_qha_input,
@@ -35,6 +37,8 @@ __all__ = [
     "QHAValidationSummary",
     "build_qha_plots",
     "build_qha_report",
+    "build_qha_inspection_plots",
+    "build_qha_inspection_report",
     "calculate_structural_thermal_expansion",
     "compare_qha_results",
     "inspect_qha_input",

--- a/src/quantas/modules/qha/api.py
+++ b/src/quantas/modules/qha/api.py
@@ -30,15 +30,46 @@ from quantas.modules.qha.io.export import QHAHDF5Export
 from quantas.modules.qha.models import QHAInput, QHAOptions, QHAResult
 from quantas.modules.qha.plot import (
     QHAPlotOptions,
+    build_pressure_volume_preview_plots,
     build_qha_plot_collection,
     describe_qha_plots,
 )
 from quantas.modules.qha.report import (
     failed_points_table,
+    pressure_volume_preview_table,
+    preview_diagnostics_table,
+    preview_parameters_table,
     result_summary_table,
     thermal_expansion_provenance_table,
     structural_property_tables,
 )
+
+
+def build_qha_inspection_report(
+    preview: PressureVolumePreview,
+) -> list[ReportTable]:
+    """Build neutral report tables from a QHA input inspection."""
+    if not isinstance(preview, PressureVolumePreview):
+        raise TypeError("preview must be a PressureVolumePreview object")
+    return [
+        pressure_volume_preview_table(preview),
+        preview_diagnostics_table(preview),
+        preview_parameters_table(preview),
+    ]
+
+
+def build_qha_inspection_plots(
+    preview: PressureVolumePreview,
+    *,
+    sample_points: int = 201,
+) -> PlotCollection:
+    """Build a neutral energy-volume plot from a QHA input inspection."""
+    if not isinstance(preview, PressureVolumePreview):
+        raise TypeError("preview must be a PressureVolumePreview object")
+    return build_pressure_volume_preview_plots(
+        preview,
+        sample_points=sample_points,
+    )
 
 
 def run_qha(

--- a/src/quantas/modules/qha/plot/__init__.py
+++ b/src/quantas/modules/qha/plot/__init__.py
@@ -3,6 +3,7 @@
 """Neutral plot builders for quasi-harmonic results."""
 
 from .inventory import describe_qha_plots
+from .inspection import build_pressure_volume_preview_plots
 from .labels import QHAPlotProperty, available_plot_properties, resolve_plot_property
 from .spec import (
     DEFAULT_PLOT_PROPERTIES,
@@ -25,6 +26,7 @@ __all__ = [
     "build_heat_capacity_spec",
     "build_property_contour_spec",
     "build_property_curve_spec",
+    "build_pressure_volume_preview_plots",
     "build_qha_plot_collection",
     "list_available_plot_properties",
     "resolve_plot_property",

--- a/src/quantas/modules/qha/plot/inspection.py
+++ b/src/quantas/modules/qha/plot/inspection.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+
+"""Neutral energy-volume plots for QHA input inspection."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from quantas.core.physics.eos import EnergyEOS
+from quantas.models import (
+    LinePlotSpec,
+    PlotAxis,
+    PlotCollection,
+    PlotSeries,
+    PlotSeriesStyle,
+)
+from quantas.modules.qha.formatting import (
+    native_energy_unit_label,
+    volume_unit_label,
+)
+from quantas.modules.qha.inspect import PressureEstimate, PressureVolumePreview
+
+
+def _sampled_fit_series(
+    estimate: PressureEstimate,
+    volume: np.ndarray,
+) -> PlotSeries | None:
+    """Return a sampled energy-fit series when an estimate is usable."""
+    if not estimate.success or estimate.fit.parameters is None:
+        return None
+
+    parameters = np.asarray(estimate.fit.parameters, dtype=np.float64)
+    if estimate.method == "polynomial":
+        energy = np.polynomial.polynomial.polyval(volume, parameters)
+        key = "polynomial_fit"
+        label = f"Polynomial fit (degree {estimate.metadata.get('degree', '?')})"
+        style = PlotSeriesStyle(color="#d97706", line_width=2.0)
+    elif estimate.method == "eos":
+        eos = str(estimate.metadata.get("eos", ""))
+        if not eos:
+            return None
+        energy = EnergyEOS().evaluate(eos, volume, parameters)
+        key = "eos_fit"
+        label = f"{eos} fit"
+        style = PlotSeriesStyle(color="#2563eb", line_width=2.0)
+    else:
+        return None
+
+    return PlotSeries(
+        key=key,
+        label=label,
+        x=volume.copy(),
+        y=np.asarray(energy, dtype=np.float64),
+        style=style,
+        metadata={
+            "method": estimate.method,
+            "fit_status": estimate.fit.status.value,
+            "fit_quality": estimate.fit.quality.value,
+        },
+    )
+
+
+def build_pressure_volume_preview_plots(
+    preview: PressureVolumePreview,
+    *,
+    sample_points: int = 201,
+) -> PlotCollection:
+    """Build an energy-volume plot from a QHA inspection preview.
+
+    The observed input values are always included. Successful polynomial and
+    EOS fits are sampled only between the minimum and maximum input volumes.
+    No extrapolation is performed.
+    """
+    if sample_points < 2:
+        raise ValueError("sample_points must be at least 2")
+    if sample_points > 10_001:
+        raise ValueError("sample_points cannot exceed 10001")
+    if preview.volume.size == 0 or preview.energy.size == 0:
+        raise ValueError("inspection preview contains no energy-volume data")
+
+    volume = np.linspace(
+        float(np.min(preview.volume)),
+        float(np.max(preview.volume)),
+        int(sample_points),
+        dtype=np.float64,
+    )
+    series = [
+        PlotSeries(
+            key="observed",
+            label="Input data",
+            x=preview.volume.copy(),
+            y=preview.energy.copy(),
+            style=PlotSeriesStyle(
+                color="#111827",
+                line_style="none",
+                marker="circle",
+                marker_size=6.0,
+            ),
+            metadata={"source": "input"},
+        )
+    ]
+    warnings_ = list(preview.warnings)
+    for estimate in (preview.polynomial, preview.eos):
+        if estimate is None:
+            continue
+        try:
+            fitted = _sampled_fit_series(estimate, volume)
+        except (TypeError, ValueError, FloatingPointError) as exc:
+            warnings_.append(
+                f"could not sample the {estimate.method} energy fit: {exc}"
+            )
+            continue
+        if fitted is not None:
+            series.append(fitted)
+
+    volume_unit = volume_unit_label(str(preview.metadata.get("volume_unit", "A")))
+    energy_unit = native_energy_unit_label(
+        str(preview.metadata.get("energy_unit", "Ha"))
+    )
+    spec = LinePlotSpec(
+        key="qha_input_energy_volume",
+        title="Static energy-volume inspection",
+        filename_stem="qha_input_energy_volume",
+        x_axis=PlotAxis(
+            key="volume",
+            label=f"V ({volume_unit})",
+            unit=volume_unit,
+        ),
+        y_axis=PlotAxis(
+            key="energy",
+            label=f"E ({energy_unit})",
+            unit=energy_unit,
+        ),
+        series=series,
+        show_legend=len(series) > 1,
+        metadata={
+            "source": "qha_inspection",
+            "sample_points": int(sample_points),
+            "volume_interval": (
+                float(np.min(preview.volume)),
+                float(np.max(preview.volume)),
+            ),
+            "extrapolated": False,
+        },
+    )
+    return PlotCollection(plots=[spec], warnings=warnings_)
+
+
+__all__ = ["build_pressure_volume_preview_plots"]

--- a/tests/infrastructure/test_api_surface.py
+++ b/tests/infrastructure/test_api_surface.py
@@ -244,6 +244,8 @@ EXPECTED_PUBLIC_SYMBOLS = {
         "ThermalExpansionMethod",
         "ValidationSummary",
         "available_energy_eos",
+        "build_inspection_plots",
+        "build_inspection_report",
         "build_plots",
         "build_report",
         "compare_results",
@@ -408,7 +410,9 @@ def test_registry_operations_are_declared_public_symbols() -> None:
         for capability, operation_name in descriptor.operations:
             assert capability in descriptor.capabilities
             assert operation_name in namespace.__all__
-            assert descriptor.operation(capability) is getattr(namespace, operation_name)
+            assert descriptor.operation(capability) is getattr(
+                namespace, operation_name
+            )
 
 
 def test_registry_dispatches_native_result_and_eos_archive(tmp_path: Path) -> None:

--- a/tests/infrastructure/test_public_api.py
+++ b/tests/infrastructure/test_public_api.py
@@ -96,7 +96,9 @@ def test_registry_declares_all_scientific_modules_and_types() -> None:
     assert registry.get("seismic").has(Capability.CREATE_INPUT)
     assert registry.get("eos").has(Capability.FIT)
     assert registry.get("eos").has(Capability.PLOT_INVENTORY)
-    assert registry.get("eos").operation(Capability.PLOT_INVENTORY) is eos.describe_plots
+    assert (
+        registry.get("eos").operation(Capability.PLOT_INVENTORY) is eos.describe_plots
+    )
     assert not registry.get("eos").has(Capability.RUN)
     assert registry.get("thermoelasticity").has(Capability.INTEROP)
     assert registry.get("eos").has(Capability.TEMPLATE)
@@ -107,19 +109,29 @@ def test_registry_declares_all_scientific_modules_and_types() -> None:
 def test_registry_describes_multiple_named_operations() -> None:
     """Frontends can enumerate operation families without guessing CLI commands."""
     elasticity_descriptor = registry.get("elasticity")
-    assert elasticity_descriptor.named_operation("create_input") is elasticity.create_input
+    assert (
+        elasticity_descriptor.named_operation("create_input") is elasticity.create_input
+    )
     assert (
         elasticity_descriptor.named_operation("export_2d_table")
         is elasticity.write_table
     )
-    assert registry.get("seismic").named_operation("create_input") is seismic.create_input
+    assert (
+        registry.get("seismic").named_operation("create_input") is seismic.create_input
+    )
+    assert (
+        registry.get("qha").named_operation("build_inspection_report")
+        is qha.build_inspection_report
+    )
+    assert (
+        registry.get("qha").named_operation("build_inspection_plots")
+        is qha.build_inspection_plots
+    )
 
     eos_exports = registry.get("eos").operations_for(Capability.EXPORT)
     assert eos_exports == (eos.write_diagnostic_csv, eos.write_calculation_csv)
 
-    thermo_exports = registry.get("thermoelasticity").list_operations(
-        Capability.EXPORT
-    )
+    thermo_exports = registry.get("thermoelasticity").list_operations(Capability.EXPORT)
     assert tuple(item.key for item in thermo_exports) == (
         "export_tensor",
         "export_grid_table",

--- a/tests/infrastructure/test_version.py
+++ b/tests/infrastructure/test_version.py
@@ -17,7 +17,7 @@ from quantas.cli.main import main
 from quantas.models import ResultMetadata
 
 
-EXPECTED_VERSION = "2.0.0b8"
+EXPECTED_VERSION = "2.0.0b9"
 
 
 def test_public_version_uses_authoritative_version():

--- a/tests/modules/qha/test_inspect.py
+++ b/tests/modules/qha/test_inspect.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from quantas.api import qha as public_qha
 from quantas.modules.qha.api import inspect_qha_input
 from quantas.modules.qha.inspect import PressureVolumePreview, pressure_volume_preview
 from quantas.modules.qha.models import QHAInput, QHAOptions
@@ -94,3 +95,76 @@ def test_pressure_volume_preview_reports_failed_eos_without_failing_polynomial()
     assert not preview.eos.success
     assert preview.warnings
     assert all(row["pressure_eos"] is None for row in preview.table_rows())
+
+
+def test_public_inspection_builders_report_and_plot_selected_fits() -> None:
+    """Public builders should expose tables and sampled E(V) curves."""
+    options = public_qha.Options(
+        energy_unit="eV",
+        volume_unit="angstrom",
+        pressure_unit="GPa",
+        energy_degree=2,
+        eos="BM3",
+    )
+    preview = public_qha.inspect(make_static_input(), options=options)
+
+    tables = public_qha.build_inspection_report(preview)
+    plots = public_qha.build_inspection_plots(preview, sample_points=51)
+
+    assert [table.title for table in tables] == [
+        "Pressure-volume preview",
+        "Pressure-volume fit diagnostics",
+        "Pressure-volume fit parameters",
+    ]
+    assert len(plots.plots) == 1
+    plot = plots.plots[0]
+    assert plot.key == "qha_input_energy_volume"
+    assert [series.key for series in plot.series] == [
+        "observed",
+        "polynomial_fit",
+        "eos_fit",
+    ]
+    assert np.array_equal(plot.series[0].x, preview.volume)
+    assert np.array_equal(plot.series[0].y, preview.energy)
+    assert plot.series[1].x.size == 51
+    assert plot.series[2].x.size == 51
+    assert plot.metadata["volume_interval"] == (69.0, 75.0)
+    assert plot.metadata["extrapolated"] is False
+
+
+def test_inspection_plot_omits_failed_fit_and_preserves_warning() -> None:
+    """An unusable EOS should not prevent plotting the data and polynomial."""
+    preview = public_qha.inspect(
+        make_static_input(),
+        options=public_qha.Options(
+            energy_unit="eV",
+            volume_unit="angstrom",
+            pressure_unit="GPa",
+            energy_degree=2,
+        ),
+        eos="not-an-eos",
+    )
+
+    plots = public_qha.build_inspection_plots(preview)
+
+    assert [series.key for series in plots.plots[0].series] == [
+        "observed",
+        "polynomial_fit",
+    ]
+    assert plots.warnings
+
+
+def test_inspection_builders_validate_public_inputs() -> None:
+    """Inspection presentation builders should reject invalid contracts."""
+    with pytest.raises(TypeError, match="Preview"):
+        public_qha.build_inspection_report(object())  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="Preview"):
+        public_qha.build_inspection_plots(object())  # type: ignore[arg-type]
+
+    preview = public_qha.inspect(
+        make_static_input(),
+        options=public_qha.Options(energy_degree=2),
+        include_eos=False,
+    )
+    with pytest.raises(ValueError, match="at least 2"):
+        public_qha.build_inspection_plots(preview, sample_points=1)

--- a/tools/README.md
+++ b/tools/README.md
@@ -13,7 +13,7 @@ public Python API or the installed ``quantas`` command.
 - ``validate_public_lifecycle_api.ps1`` runs the focused public input, run,
   persistence, report, plot, export, registry, and CLI/API-equivalence checks
   on Windows. The ``-Full`` switch adds Ruff, mypy, the complete staged suite,
-  Sphinx, and distribution validation for a candidate ``2.0.0b8`` snapshot.
+  Sphinx, and distribution validation for a candidate ``2.0.0b9`` snapshot.
 - ``validate_public_plot_api.ps1`` is a compatibility entry point forwarding
   to the lifecycle validation script.
 - ``post_validation_cleanup.sh`` removes disposable validation environments,

--- a/tools/validate_public_lifecycle_api.ps1
+++ b/tools/validate_public_lifecycle_api.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-Validate the in-development Quantas 2.0.0b8 public lifecycle API on Windows.
+Validate the in-development Quantas 2.0.0b9 public lifecycle API on Windows.
 
 .DESCRIPTION
 Runs focused public input, execution, persistence, report, plot, export,

--- a/tools/validate_public_lifecycle_api_step6.ps1
+++ b/tools/validate_public_lifecycle_api_step6.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-Validate the in-development Quantas 2.0.0b8 public lifecycle API on Windows.
+Validate the in-development Quantas 2.0.0b9 public lifecycle API on Windows.
 
 .DESCRIPTION
 Runs focused public input, execution, persistence, report, plot, export,


### PR DESCRIPTION
Added public QHA input-inspection report and energy-volume plot builders. They expose observed points, the selected polynomial and EOS fits, fitted parameters, residual diagnostics, and warnings without requiring frontends to reproduce equation-of-state formulas.

### Changed

- Routed `quantas qha inspect` report construction through the same public inspection-report builder available to GUI and library clients.

### Scientific compatibility

No scientific formula, physical convention, HDF5 payload, or stored numerical result was changed.